### PR TITLE
eliminate unnecessary conversion; p6 question

### DIFF
--- a/lab11/README.md
+++ b/lab11/README.md
@@ -229,22 +229,16 @@ Now, let's do an elementwise comparison to get a True in every place where there
 a % 2 == 0
 ```
 
-It will be easier to count matches if we represent True as 1 and False as 0:
-
-```python
-(a % 2 == 0).astype(int)
-```
-
 How many is that?
 
 ```python
-(a % 2 == 0).astype(int).sum()
+(a % 2 == 0).sum()
 ```
 
 And what percent of the total is that?
 
 ```python
-(a % 2 == 0).astype(int).mean() * 100
+(a % 2 == 0).mean() * 100
 ```
 
 This may be useful for counting what percentage of an area matches a


### PR DESCRIPTION
I ran the code below and found that converting to int slowed down an identical calculation. Would love to hear your thoughts if I'm going crazy. On that point, I'm curious if there was a way to use .mean() when we had to eliminate matrix == 0? I found that I needed to do division after two separate sums because trying to write matrix != 0 and matrix == 11 would break the elementwise comparison syntax, and I didn't find a way to use .any() or .all() to fix it.

import time
t0 = time.time()
result = (matrix == 11).sum()/(matrix != 0).sum()
t1 = time.time()
time1 = t1-t0
print(f"Time to complete without conversion was {time1} ms, result was {result}")
t0 = time.time()
result = (matrix == 11).astype(int).sum()/(matrix != 0).astype(int).sum()
t1 = time.time()
time2 = t1-t0
print(f"Time to complete with conversion was {time2} ms, result was {result}")
print(f"Converting slowed code down by {time2-time1} ms, for an average of {(time2-time1)/matrix.size} per element.")

# Expected Output:
# Time to complete without conversion was 0.008191585540771484 ms, result was 0.018682146559888153
# Time to complete with conversion was 0.01536250114440918 ms, result was 0.018682146559888153
# Converting slowed code down by 0.007170915603637695 ms, for an average of 2.9880421087790533e-09 per element.

# Reflection:
# the time savings per element are negligible while technically measurable.
# that said, I think the code without conversion is both more readable and efficient, so it should be replaced